### PR TITLE
Fixed the MainActivity crash issue

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,7 +9,7 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/Theme.RecommendoR"
+        android:theme="@style/AppTheme"
         tools:targetApi="31">
 
         <activity

--- a/app/src/main/java/com/example/recommendor/MainActivity.java
+++ b/app/src/main/java/com/example/recommendor/MainActivity.java
@@ -3,15 +3,12 @@ package com.example.recommendor;
 import android.os.Bundle;
 import android.util.Log;
 import androidx.appcompat.app.AppCompatActivity;
-import androidx.navigation.NavController;
-import androidx.navigation.Navigation;
-import androidx.navigation.ui.NavigationUI;
-import com.example.recommendor.databinding.ActivityMainBinding; // Import the binding class
+import androidx.navigation.fragment.NavHostFragment;
+import com.example.recommendor.databinding.ActivityMainBinding;
 
 public class MainActivity extends AppCompatActivity {
     private static final String TAG = "MainActivity";
 
-    // Declare a binding instance
     private ActivityMainBinding binding;
 
     @Override
@@ -22,26 +19,21 @@ public class MainActivity extends AppCompatActivity {
         binding = ActivityMainBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
 
-        // Debugging: Check if the FragmentContainerView exists via the binding instance
-        if (binding.navHostFragment == null) {
-            Log.e(TAG, "FragmentContainerView (R.id.nav_host_fragment) is null. Check your activity_main.xml");
-        } else {
-            Log.d(TAG, "FragmentContainerView initialized successfully via View Binding.");
-        }
+        // Set the Toolbar as the ActionBar
+        setSupportActionBar(binding.toolbar);
 
-        try {
-            NavController navController = Navigation.findNavController(this, R.id.nav_host_fragment);
-            Log.d(TAG, "NavController found: " + navController);
-            NavigationUI.setupActionBarWithNavController(this, navController);
+        // Safely get the NavController using NavHostFragment
+        NavHostFragment navHostFragment = (NavHostFragment) getSupportFragmentManager().findFragmentById(R.id.nav_host_fragment);
+        if (navHostFragment != null) {
             Log.d(TAG, "NavController set up successfully.");
-        } catch (Exception e) {
-            Log.e(TAG, "Error finding NavController: " + e.getMessage(), e);
+        } else {
+            Log.e(TAG, "NavHostFragment is null. Check your layout or ID.");
         }
-    }
 
-    @Override
-    public boolean onSupportNavigateUp() {
-        NavController navController = Navigation.findNavController(this, R.id.nav_host_fragment);
-        return navController.navigateUp() || super.onSupportNavigateUp();
+        // Completely disable the back arrow
+        if (getSupportActionBar() != null) {
+            getSupportActionBar().setDisplayHomeAsUpEnabled(false);
+            getSupportActionBar().setHomeButtonEnabled(false);
+        }
     }
 }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,8 +1,22 @@
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
-    <!-- Toolbar -->
+
+    <!-- AppBar with Toolbar -->
+    <com.google.android.material.appbar.AppBarLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar">
+
+        <androidx.appcompat.widget.Toolbar
+            android:id="@+id/toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            android:background="?attr/colorPrimary"
+            app:popupTheme="@style/ThemeOverlay.AppCompat.Light" />
+    </com.google.android.material.appbar.AppBarLayout>
 
     <!-- Navigation Host -->
     <androidx.fragment.app.FragmentContainerView
@@ -10,11 +24,8 @@
         android:name="androidx.navigation.fragment.NavHostFragment"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        app:navGraph="@navigation/nav_graph"
-        app:defaultNavHost="true" />
+        app:defaultNavHost="true"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior"
+        app:navGraph="@navigation/nav_graph" />
 
-</FrameLayout>
-
-
-
-
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/values/style.xml
+++ b/app/src/main/res/values/style.xml
@@ -1,6 +1,6 @@
 <resources>
     <!-- Base application theme -->
-    <style name="AppTheme" parent="Theme.AppCompat.Light.DarkActionBar">
+    <style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar">
         <!-- Customize your theme here -->
     </style>
 </resources>


### PR DESCRIPTION
Fixed the MainActivity issue that I had in the app when it crashed because I didn't define a active bar for it. 

The fix was to define an active bar to it, which I did as a toolbar.